### PR TITLE
Don't break IE8 by assuming add/removeEventListener.

### DIFF
--- a/build/image-gallery.js
+++ b/build/image-gallery.js
@@ -86,11 +86,20 @@ var ImageGallery = _react2['default'].createClass({
     if (this.props.autoPlay) {
       this.play();
     }
-    window.addEventListener('resize', this._handleResize);
+    if (window.addEventListener) {
+      window.addEventListener('resize', this._handleResize);
+    } else if (window.attachEvent) {
+      window.attachEvent('onresize', this._handleResize);
+    }
   },
 
   componentWillUnmount: function componentWillUnmount() {
-    window.removeEventListener('resize', this._handleResize);
+    if (window.removeEventListener) {
+      window.removeEventListener('resize', this._handleResize);
+    } else if (window.detachEvent) {
+      window.detachEvent('onresize', this._handleResize);
+    }
+
     if (this._intervalId) {
       window.clearInterval(this._intervalId);
       this._intervalId = null;

--- a/src/ImageGallery.react.jsx
+++ b/src/ImageGallery.react.jsx
@@ -83,11 +83,20 @@ const ImageGallery = React.createClass({
     if (this.props.autoPlay) {
       this.play();
     }
-    window.addEventListener('resize', this._handleResize);
+    if (window.addEventListener) {
+      window.addEventListener('resize', this._handleResize);
+    } else if (window.attachEvent) {
+      window.attachEvent('onresize', this._handleResize);
+    }
   },
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this._handleResize);
+    if (window.removeEventListener) {
+      window.removeEventListener('resize', this._handleResize);
+    } else if (window.detachEvent) {
+      window.detachEvent('onresize', this._handleResize);
+    }
+
     if (this._intervalId) {
       window.clearInterval(this._intervalId);
       this._intervalId = null;


### PR DESCRIPTION
Added add/detachEvent calls as alternative to add/removeEventListener, to prevent errors in IE8.

Since React officially supports IE8 and [addEventListener polyfills have a tendency to break event handling][1] in React, it's nice when components support IE8 out of the box.

[1]: https://github.com/facebook/react/issues/3131#issuecomment-128732009