### PR TITLE
Don't render arrows when there are less than two items

### DIFF
--- a/build/image-gallery.js
+++ b/build/image-gallery.js
@@ -208,6 +208,32 @@ var ImageGallery = _react2['default'].createClass({
     return alignment;
   },
 
+  renderSlides: function renderSlides(slides) {
+    return this.props.items.length >= 2 ? [_react2['default'].createElement('a', { key: 'leftNav',
+      className: 'image-gallery-left-nav',
+      onTouchStart: this.swipePrev,
+      onClick: this.swipePrev }), _react2['default'].createElement('a', {
+      key: 'rightNav',
+      className: 'image-gallery-right-nav',
+      onTouchStart: this.swipeNext,
+      onClick: this.swipeNext }), _react2['default'].createElement(
+      _reactSwipeable2['default'],
+      {
+        key: 'swipeable',
+        onSwipedLeft: this.swipeNext,
+        onSwipedRight: this.swipePrev },
+      _react2['default'].createElement(
+        'div',
+        { className: 'image-gallery-slides' },
+        slides
+      )
+    )] : _react2['default'].createElement(
+      'div',
+      { className: 'image-gallery-slides' },
+      slides
+    );
+  },
+
   render: function render() {
     var _this2 = this;
 
@@ -269,8 +295,8 @@ var ImageGallery = _react2['default'].createClass({
       }
     });
 
-    var swipePrev = this.slideToIndex.bind(this, currentIndex - 1);
-    var swipeNext = this.slideToIndex.bind(this, currentIndex + 1);
+    this.swipePrev = this.slideToIndex.bind(this, currentIndex - 1);
+    this.swipeNext = this.slideToIndex.bind(this, currentIndex + 1);
 
     return _react2['default'].createElement(
       'section',
@@ -281,23 +307,7 @@ var ImageGallery = _react2['default'].createClass({
           onMouseOver: this._handleMouseOver,
           onMouseLeave: this._handleMouseLeave,
           className: 'image-gallery-content' },
-        _react2['default'].createElement('a', { className: 'image-gallery-left-nav',
-          onTouchStart: swipePrev,
-          onClick: swipePrev }),
-        _react2['default'].createElement('a', { className: 'image-gallery-right-nav',
-          onTouchStart: swipeNext,
-          onClick: swipeNext }),
-        _react2['default'].createElement(
-          _reactSwipeable2['default'],
-          {
-            onSwipedLeft: swipeNext,
-            onSwipedRight: swipePrev },
-          _react2['default'].createElement(
-            'div',
-            { className: 'image-gallery-slides' },
-            slides
-          )
-        ),
+        this.renderSlides(slides),
         this.props.showBullets && _react2['default'].createElement(
           'div',
           { className: 'image-gallery-bullets' },

--- a/build/image-gallery.js
+++ b/build/image-gallery.js
@@ -208,32 +208,6 @@ var ImageGallery = _react2['default'].createClass({
     return alignment;
   },
 
-  renderSlides: function renderSlides(slides) {
-    return this.props.items.length >= 2 ? [_react2['default'].createElement('a', { key: 'leftNav',
-      className: 'image-gallery-left-nav',
-      onTouchStart: this.swipePrev,
-      onClick: this.swipePrev }), _react2['default'].createElement('a', {
-      key: 'rightNav',
-      className: 'image-gallery-right-nav',
-      onTouchStart: this.swipeNext,
-      onClick: this.swipeNext }), _react2['default'].createElement(
-      _reactSwipeable2['default'],
-      {
-        key: 'swipeable',
-        onSwipedLeft: this.swipeNext,
-        onSwipedRight: this.swipePrev },
-      _react2['default'].createElement(
-        'div',
-        { className: 'image-gallery-slides' },
-        slides
-      )
-    )] : _react2['default'].createElement(
-      'div',
-      { className: 'image-gallery-slides' },
-      slides
-    );
-  },
-
   render: function render() {
     var _this2 = this;
 
@@ -295,8 +269,8 @@ var ImageGallery = _react2['default'].createClass({
       }
     });
 
-    this.swipePrev = this.slideToIndex.bind(this, currentIndex - 1);
-    this.swipeNext = this.slideToIndex.bind(this, currentIndex + 1);
+    var swipePrev = this.slideToIndex.bind(this, currentIndex - 1);
+    var swipeNext = this.slideToIndex.bind(this, currentIndex + 1);
 
     return _react2['default'].createElement(
       'section',
@@ -307,7 +281,29 @@ var ImageGallery = _react2['default'].createClass({
           onMouseOver: this._handleMouseOver,
           onMouseLeave: this._handleMouseLeave,
           className: 'image-gallery-content' },
-        this.renderSlides(slides),
+        this.props.items.length >= 2 ? [_react2['default'].createElement('a', { key: 'leftNav',
+          className: 'image-gallery-left-nav',
+          onTouchStart: swipePrev,
+          onClick: swipePrev }), _react2['default'].createElement('a', {
+          key: 'rightNav',
+          className: 'image-gallery-right-nav',
+          onTouchStart: swipeNext,
+          onClick: swipeNext }), _react2['default'].createElement(
+          _reactSwipeable2['default'],
+          {
+            key: 'swipeable',
+            onSwipedLeft: swipeNext,
+            onSwipedRight: swipePrev },
+          _react2['default'].createElement(
+            'div',
+            { className: 'image-gallery-slides' },
+            slides
+          )
+        )] : _react2['default'].createElement(
+          'div',
+          { className: 'image-gallery-slides' },
+          slides
+        ),
         this.props.showBullets && _react2['default'].createElement(
           'div',
           { className: 'image-gallery-bullets' },

--- a/src/ImageGallery.react.jsx
+++ b/src/ImageGallery.react.jsx
@@ -203,6 +203,35 @@ const ImageGallery = React.createClass({
     return alignment;
   },
 
+  renderSlides(slides) {
+     return this.props.items.length >= 2 ?
+       [
+         <a key='leftNav'
+           className='image-gallery-left-nav'
+           onTouchStart={this.swipePrev}
+           onClick={this.swipePrev}/>,
+
+         <a
+           key='rightNav'
+           className='image-gallery-right-nav'
+           onTouchStart={this.swipeNext}
+           onClick={this.swipeNext}/>,
+
+         <Swipeable
+           key='swipeable'
+           onSwipedLeft={this.swipeNext}
+           onSwipedRight={this.swipePrev}>
+             <div className='image-gallery-slides'>
+               {slides}
+             </div>
+         </Swipeable>
+       ]
+     :
+     <div className='image-gallery-slides'>
+       {slides}
+     </div>
+  },
+
   render() {
     let currentIndex = this.state.currentIndex;
     let thumbnailStyle = {
@@ -270,8 +299,8 @@ const ImageGallery = React.createClass({
       }
     });
 
-    let swipePrev = this.slideToIndex.bind(this, currentIndex - 1);
-    let swipeNext = this.slideToIndex.bind(this, currentIndex + 1);
+    this.swipePrev = this.slideToIndex.bind(this, currentIndex - 1);
+    this.swipeNext = this.slideToIndex.bind(this, currentIndex + 1);
 
     return (
       <section ref='imageGallery' className='image-gallery'>
@@ -280,21 +309,7 @@ const ImageGallery = React.createClass({
           onMouseLeave={this._handleMouseLeave}
           className='image-gallery-content'>
 
-          <a className='image-gallery-left-nav'
-            onTouchStart={swipePrev}
-            onClick={swipePrev}/>
-
-          <a className='image-gallery-right-nav'
-            onTouchStart={swipeNext}
-            onClick={swipeNext}/>
-
-          <Swipeable
-            onSwipedLeft={swipeNext}
-            onSwipedRight={swipePrev}>
-              <div className='image-gallery-slides'>
-                {slides}
-              </div>
-          </Swipeable>
+          {this.renderSlides(slides)}
 
           {
             this.props.showBullets &&

--- a/src/ImageGallery.react.jsx
+++ b/src/ImageGallery.react.jsx
@@ -203,35 +203,6 @@ const ImageGallery = React.createClass({
     return alignment;
   },
 
-  renderSlides(slides) {
-     return this.props.items.length >= 2 ?
-       [
-         <a key='leftNav'
-           className='image-gallery-left-nav'
-           onTouchStart={this.swipePrev}
-           onClick={this.swipePrev}/>,
-
-         <a
-           key='rightNav'
-           className='image-gallery-right-nav'
-           onTouchStart={this.swipeNext}
-           onClick={this.swipeNext}/>,
-
-         <Swipeable
-           key='swipeable'
-           onSwipedLeft={this.swipeNext}
-           onSwipedRight={this.swipePrev}>
-             <div className='image-gallery-slides'>
-               {slides}
-             </div>
-         </Swipeable>
-       ]
-     :
-     <div className='image-gallery-slides'>
-       {slides}
-     </div>
-  },
-
   render() {
     let currentIndex = this.state.currentIndex;
     let thumbnailStyle = {
@@ -299,8 +270,8 @@ const ImageGallery = React.createClass({
       }
     });
 
-    this.swipePrev = this.slideToIndex.bind(this, currentIndex - 1);
-    this.swipeNext = this.slideToIndex.bind(this, currentIndex + 1);
+    let swipePrev = this.slideToIndex.bind(this, currentIndex - 1);
+    let swipeNext = this.slideToIndex.bind(this, currentIndex + 1);
 
     return (
       <section ref='imageGallery' className='image-gallery'>
@@ -308,9 +279,34 @@ const ImageGallery = React.createClass({
           onMouseOver={this._handleMouseOver}
           onMouseLeave={this._handleMouseLeave}
           className='image-gallery-content'>
+          {
+            this.props.items.length >= 2 ?
+            [
+             <a key='leftNav'
+               className='image-gallery-left-nav'
+               onTouchStart={swipePrev}
+               onClick={swipePrev}/>,
 
-          {this.renderSlides(slides)}
+             <a
+               key='rightNav'
+               className='image-gallery-right-nav'
+               onTouchStart={swipeNext}
+               onClick={swipeNext}/>,
 
+             <Swipeable
+               key='swipeable'
+               onSwipedLeft={swipeNext}
+               onSwipedRight={swipePrev}>
+                 <div className='image-gallery-slides'>
+                   {slides}
+                 </div>
+             </Swipeable>
+            ]
+            :
+            <div className='image-gallery-slides'>
+              {slides}
+            </div>
+          }
           {
             this.props.showBullets &&
               <div className='image-gallery-bullets'>


### PR DESCRIPTION
I use this library in my website and I really like it. I added a condition in the rendering of the arrows since it doesn't make sense to keep them when there's one or zero images. Confuses the users.
