### PR TITLE
Fixes 'loaded' class being added multiple times to lazy-loaded images

### DIFF
--- a/src/ImageGallery.react.jsx
+++ b/src/ImageGallery.react.jsx
@@ -213,7 +213,9 @@ const ImageGallery = React.createClass({
   },
 
   _handleImageLoad(event) {
-    event.target.className += 'loaded';
+    if (event.target.className.indexOf('loaded') === -1) {
+      event.target.className += ' loaded';
+    }
   },
 
   render() {


### PR DESCRIPTION
Noticed this when using the component with dynamic images that allow browsing through multiple ImageGalleries. The images will end up with a class like "loadedloadedloadedloaded", depending on how many times the individual image was viewed, which can cause issues with the .loaded css class and prevent the image from being displayed.