### PR TITLE
Resets currentIndex on props.items change

### DIFF
--- a/src/ImageGallery.react.jsx
+++ b/src/ImageGallery.react.jsx
@@ -87,6 +87,12 @@ const ImageGallery = React.createClass({
 
   },
 
+  componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+    if (nextProps.items.length) {
+      this.setState({ currentIndex: 0 });
+    }
+  },
+
   componentDidMount() {
     this._handleResize();
     if (this.props.autoPlay) {


### PR DESCRIPTION
If you change the ImageGallery items property dynamically, then the currentIndex retains its value. For example: if you have a gallery with 4 items that had its third image clicked/viewed last and then change the items property to another set of images, then it will try to display the third image again, as its currentIndex is still set to that value. 
This is not much of a problem if you are always using the same amount of images, it will just start with the currentIndex image instead of the first image, but if there are less images than currentIndex, then it will just display an empty space.

This pull request ensures that the currentIndex state gets reset to 0 whenever the items property has been set. That way changing the ImageGallery items property dynamically will always make it start at the first image again.