### PR TITLE
FEATURE: Adds defaultImage props, used as placeholder for invalid images

### DIFF
--- a/src/ImageGallery.react.jsx
+++ b/src/ImageGallery.react.jsx
@@ -227,7 +227,7 @@ const ImageGallery = React.createClass({
   },
 
   _handleImageError(event) {
-    if (this.props.defaultImage) {
+    if (this.props.defaultImage && event.target.src.indexOf(this.props.defaultImage) === -1) {
       event.target.src = this.props.defaultImage;
     }
   },

--- a/src/ImageGallery.react.jsx
+++ b/src/ImageGallery.react.jsx
@@ -19,7 +19,8 @@ const ImageGallery = React.createClass({
     slideInterval: React.PropTypes.number,
     onSlide: React.PropTypes.func,
     onClick: React.PropTypes.func,
-    startIndex: React.PropTypes.number
+    startIndex: React.PropTypes.number,
+    defaultImage: React.PropTypes.string
   },
 
   getDefaultProps() {
@@ -225,6 +226,12 @@ const ImageGallery = React.createClass({
     }
   },
 
+  _handleImageError(event) {
+    if (this.props.defaultImage) {
+      event.target.src = this.props.defaultImage;
+    }
+  },
+
   render() {
     let currentIndex = this.state.currentIndex;
     let thumbnailStyle = {
@@ -250,7 +257,7 @@ const ImageGallery = React.createClass({
           className={'image-gallery-slide' + alignment + originalClass}
           onClick={this.props.onClick}
           onTouchStart={this.props.onClick}>
-            <img src={item.original} onLoad={this._handleImageLoad}/>
+            <img src={item.original} onLoad={this._handleImageLoad} onError={this._handleImageError}/>
             {item.description}
         </div>
       );
@@ -276,7 +283,7 @@ const ImageGallery = React.createClass({
             onTouchStart={this.slideToIndex.bind(this, index)}
             onClick={this.slideToIndex.bind(this, index)}>
 
-            <img src={item.thumbnail}/>
+            <img src={item.thumbnail} onError={this._handleImageError}/>
           </a>
         );
       }


### PR DESCRIPTION
Adds a new optional defaultImage property, which is used for the main and thumbnail images if the image failed to load, e.g.: broken link. It requires the full path to the image.
Usage:

```
<ImageGallery
          items={caseImages}
          defaultImage='/img/default.jpg'
/>
```

This commit is based on the request in issue #11 

(I wanted to keep this out of the other recent pull request, since this is a feature addition.)