### PR TITLE
Prop for disabling scrolling of thumbnails

### DIFF
--- a/src/ImageGallery.react.jsx
+++ b/src/ImageGallery.react.jsx
@@ -21,6 +21,7 @@ const ImageGallery = React.createClass({
     onClick: React.PropTypes.func,
     startIndex: React.PropTypes.number,
     defaultImage: React.PropTypes.string,
+    disableScrolling: React.PropTypes.bool,
     server: React.PropTypes.bool
   },
 
@@ -35,6 +36,7 @@ const ImageGallery = React.createClass({
       autoPlay: false,
       slideInterval: 4000,
       startIndex: 0,
+      disableScrolling: false,
       server: false
     };
   },
@@ -160,6 +162,9 @@ const ImageGallery = React.createClass({
   },
 
   _getScrollX(indexDifference) {
+    if (this.props.disableScrolling) {
+      return 0;
+    }
     if (this._thumbnails) {
       if (this._thumbnails.scrollWidth <= this.state.containerWidth) {
         return 0;

--- a/src/ImageGallery.react.jsx
+++ b/src/ImageGallery.react.jsx
@@ -143,7 +143,7 @@ const ImageGallery = React.createClass({
       if (!this.state.hovering) {
         this.slideToIndex(this.state.currentIndex + 1);
       }
-    }.bind(this), this.props.slideInterval);
+    }, this.props.slideInterval);
   },
 
   pause() {


### PR DESCRIPTION
I've added a prop called "disableScrolling" that will disable scrolling of the thumbnails. In my case, I have a CSS that layouts the thumbnails in multiple lines and no scrolling is required. 

I've also added some missing parentheses.